### PR TITLE
repl: Print stdout/stderr on goimports error

### DIFF
--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -349,9 +350,14 @@ func (s *Session) Eval(in string) (string, error, bytes.Buffer) {
 			}
 			f.Close()
 
+			b := new(bytes.Buffer)
 			cmd := exec.Command("goimports", "-w", string(filepath.Dir(s.FilePath))+"/func_proxy.go")
+			cmd.Stdout = b
+			cmd.Stderr = b
 			err = cmd.Run()
 			if err != nil {
+				os.Stderr.WriteString("Error running goimports:\n")
+				io.Copy(os.Stderr, b)
 				panic(err)
 			}
 


### PR DESCRIPTION
If the program exits with a non-zero return code, the only info you get is
"exit status 2", which is unhelpful at determining what went wrong.