### PR TITLE
import improvements, linting

### DIFF
--- a/execution.go
+++ b/execution.go
@@ -57,7 +57,7 @@ func HandleExecuteRequest(receipt MsgReceipt) {
 	content["execution_count"] = ExecCounter
 
 	// Do the compilation/execution magic.
-	val, err, stderr := REPLSession.Eval(code)
+	val, stderr, err := REPLSession.Eval(code)
 
 	if err == nil {
 		content["status"] = "ok"

--- a/gophernotes_test.go
+++ b/gophernotes_test.go
@@ -31,7 +31,7 @@ func TestRun_import(t *testing.T) {
 	}
 
 	for _, code := range codes {
-		_, err, _ := s.Eval(code)
+		_, _, err := s.Eval(code)
 		noError(t, err)
 	}
 }
@@ -52,7 +52,7 @@ func TestRun_QuickFix_evaluated_but_not_used(t *testing.T) {
 	}
 
 	for _, code := range codes {
-		_, err, _ := s.Eval(code)
+		_, _, err := s.Eval(code)
 		noError(t, err)
 	}
 }
@@ -70,7 +70,7 @@ func TestRun_QuickFix_used_as_value(t *testing.T) {
 	}
 
 	for _, code := range codes {
-		_, err, _ := s.Eval(code)
+		_, _, err := s.Eval(code)
 		noError(t, err)
 	}
 }
@@ -90,7 +90,7 @@ func TestRun_Copy(t *testing.T) {
 	}
 
 	for _, code := range codes {
-		_, err, _ := s.Eval(code)
+		_, _, err := s.Eval(code)
 		noError(t, err)
 	}
 }
@@ -107,7 +107,7 @@ func TestRun_Const(t *testing.T) {
 	}
 
 	for _, code := range codes {
-		_, err, _ := s.Eval(code)
+		_, _, err := s.Eval(code)
 		noError(t, err)
 	}
 }


### PR DESCRIPTION
- improves importing, such that:
    - you can import multiple things in a single cell
    - you can import without using the `:` syntax
    - the new changes are backwards compatible with the `:` syntax
- fixes to get inline with `golint`

![](https://cloud.githubusercontent.com/assets/4524535/17551861/156ef4a6-5ec2-11e6-9c4e-20a80dd0093c.png)
