### PR TITLE
Simplify kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Then:
         "/Users/<your username>/go/bin/gophernotes",
         "{connection_file}"
         ],
-      "display_name": "Golang",
+      "display_name": "Go",
       "language": "go",
       "name": "go"
   }

--- a/kernel/kernel.json
+++ b/kernel/kernel.json
@@ -3,7 +3,7 @@
 		"gophernotes",
     	"{connection_file}"
     	],
-    "display_name": "Golang",
+    "display_name": "Go",
     "language": "go",
     "name": "go"
 }

--- a/kernel/kernel.json
+++ b/kernel/kernel.json
@@ -1,6 +1,6 @@
 {
     "argv": [
-    	"/go/bin/gophernotes", 
+		"gophernotes",
     	"{connection_file}"
     	],
     "display_name": "Golang",


### PR DESCRIPTION
this CL modifies the default `kernel.json` config file to not hard-code some path to the `gophernotes` executable. (tested on mybinder.org/repo/gopherds/mybinder-go)

This CL also modifies the displayed name of the Go kernel: the language is called Go, not Golang :)