### PR TITLE
kernel.json path is wrong for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Then:
   jupyter --data-dir
   ```
 
-4. Update `~/.local/share/jupyter/kernels/gophernotes/kernel.json` with the FULL PATH to your gophernotes binary (in $GOPATH/bin).  For example:
+4. Update `~/Library/Jupyter/kernels/gophernotes/kernel.json` with the FULL PATH to your gophernotes binary (in $GOPATH/bin).  For example:
 
   ```
   {


### PR DESCRIPTION
`~/.local/share/jupyter/kernels/gopherlab` is the location for Linux, but not macOS. This should be `~/Library/Jupyter/kernels/gophernotes/kernel.json`.